### PR TITLE
Use ISO 8601-like YYYY-MM-DD date format for email/file logging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,7 @@ Changelog
 
 Unreleased
 
+* Use ISO 8601-like YYYY-MM-DD date format for email/file logging.
 * Fixed deprecation warnings on Python 3.12 (utcnow function).
 * Enabled CI testing with Python 3.11, 3.12 and Django 5.0, 4.2, 4.1.
 

--- a/dogslow_sentry/__init__.py
+++ b/dogslow_sentry/__init__.py
@@ -191,12 +191,12 @@ class WatchdogMiddleware(object):
             "Process ID: %d\n"
             "Started:    %s\n\n"
             % (
-                utcnow().strftime("%d-%m-%Y %H:%M:%S %Z"),
+                utcnow().strftime("%Y-%m-%d %H:%M:%S %Z"),
                 req_string,
                 socket.gethostname(),
                 thread_id,
                 os.getpid(),
-                started.strftime("%d-%m-%Y %H:%M:%S %Z"),
+                started.strftime("%Y-%m-%d %H:%M:%S %Z"),
             )
         )
         output += stack(frame, with_locals=False)


### PR DESCRIPTION
Previously DD-MM-YYYY format was used in messages for DOGSLOW_LOG_TO_FILE/DOGSLOW_EMAIL_TO.

Not totally ISO 8601, using space as date-time separator instead of "T".