### PR TITLE
CI: Update tests for Sentry 1.40+

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-django
+sentry-sdk

--- a/tox.ini
+++ b/tox.ini
@@ -18,9 +18,7 @@ python_files = tests.py
 # See https://www.djangoproject.com/download/ for list of Django releases
 # And https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
 deps =
-    pytest
-    pytest-django
-    sentry-sdk
+    -r test-requirements.txt
     dj22: Django~=2.2.0
     dj30: Django~=3.0.0
     dj32: Django~=3.2.0


### PR DESCRIPTION
Adapting to some changes to internal logic in Sentry 1.40.